### PR TITLE
Fixing es-abstract version

### DIFF
--- a/loom/package-lock.json
+++ b/loom/package-lock.json
@@ -1451,9 +1451,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-      "integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",


### PR DESCRIPTION
Fixing `npm install` that is failing due nonexistent `es-abstract` v.0.14.0 dep package.  
([404 https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz](https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz)).  
  
